### PR TITLE
chore: fix README SDK version reference from 6 to 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ We've built a simple console that demonstrates how LaunchDarkly's OpenFeature pr
 
 ## Build instructions
 
-This project uses Gradle. It requires that Java is already installed on your system (version 11 or higher). It will automatically use the latest release of the LaunchDarkly SDK with major version 6.
+This project uses Gradle. It requires that Java is already installed on your system (version 11 or higher). It will automatically use the latest release of the LaunchDarkly SDK with major version 7.
 
 1. Set the environment variable `LAUNCHDARKLY_SDK_KEY` to your LaunchDarkly SDK key. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set `LAUNCHDARKLY_FLAG_KEY` to the flag key; otherwise, a boolean flag of `sample-feature` will be assumed.
 


### PR DESCRIPTION
## Summary

Fixes an incorrect SDK major version reference in the README. The `build.gradle` specifies the Java Server SDK dependency as `[7.0.0, 8.0.0)` (major version 7), but the README stated major version 6.

## Review & Testing Checklist for Human

- [ ] Confirm `build.gradle` dependency version range `[7.0.0, 8.0.0)` aligns with the updated README text ("major version 7")

### Notes

Verified the app builds and runs successfully with `./gradlew run` against the current SDK version (7.9.1).

Link to Devin session: https://app.devin.ai/sessions/7934e3fa94484fe4a85e5f08a85515cb
Requested by: @kinyoklion